### PR TITLE
Add timeout to hosted Windows build

### DIFF
--- a/.github/workflows/build-run.yaml
+++ b/.github/workflows/build-run.yaml
@@ -272,6 +272,7 @@ jobs:
 
     win32:
         runs-on: windows-latest
+        timeout-minutes: 60
         needs:
             - web
         steps:

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -130,7 +130,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
-                  cache: 'npm'
 
             # #
             #   Initialize › Node Clean Install
@@ -221,7 +220,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
-                  cache: 'npm'
 
             # #
             #   Lint › NPM Install
@@ -282,7 +280,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
-                  cache: 'npm'
 
             # #
             #   Test › NPM Install


### PR DESCRIPTION
## Summary
- add a hard timeout to the hosted Windows build job so a stalled run cannot burn through Actions quota

## Verification
- python3 /Users/mick/projects/infra-services/scripts/github/audit_workflow_timeouts.py --repo-root /Users/mick/projects/wt/keeweb-timeout-guard