### PR TITLE
Align KeeWeb macOS deploy wrapper with app replacement flow

### DIFF
--- a/.github/workflows/build-run.yaml
+++ b/.github/workflows/build-run.yaml
@@ -193,7 +193,7 @@ jobs:
     # #
 
     darwin:
-        runs-on: [self-hosted, macOS, mick-macbook]
+        runs-on: [self-hosted, macOS, general-ci]
         needs:
             - web
         steps:

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -92,7 +92,7 @@ jobs:
     job-initialize:
         name: >-
             💡 Initialize
-        runs-on: [self-hosted, macOS, mick-macbook]
+        runs-on: [self-hosted, macOS, general-ci]
         outputs:
             package_version: ${{ steps.task_init_pkg_ver_get.outputs.PACKAGE_VERSION }}
             guid: ${{ steps.task_init_dotenv_get.outputs.GUID }}
@@ -193,7 +193,7 @@ jobs:
     job-lint:
         name: >-
             📚 Lint
-        runs-on: [self-hosted, macOS, mick-macbook]
+        runs-on: [self-hosted, macOS, general-ci]
         needs: [job-initialize]
         env:
             PACKAGE_VERSION: ${{ needs.job-initialize.outputs.package_version }}
@@ -246,7 +246,7 @@ jobs:
     job-test:
         name: >-
             🧪 Tests
-        runs-on: [self-hosted, macOS, mick-macbook]
+        runs-on: [self-hosted, macOS, general-ci]
         needs: [job-initialize]
         env:
             PACKAGE_VERSION: ${{ needs.job-initialize.outputs.package_version }}
@@ -306,7 +306,7 @@ jobs:
     job-complete-run:
         name: >-
             ✅ Complete
-        runs-on: [self-hosted, macOS, mick-macbook]
+        runs-on: [self-hosted, macOS, general-ci]
         needs: [job-initialize, job-lint, job-test]
         env:
             PACKAGE_VERSION: ${{ needs.job-initialize.outputs.package_version }}

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -92,7 +92,7 @@ jobs:
     job-initialize:
         name: >-
             💡 Initialize
-        runs-on: [self-hosted, macOS, general-ci]
+        runs-on: [self-hosted, macOS, mick-macbook]
         outputs:
             package_version: ${{ steps.task_init_pkg_ver_get.outputs.PACKAGE_VERSION }}
             guid: ${{ steps.task_init_dotenv_get.outputs.GUID }}
@@ -193,7 +193,7 @@ jobs:
     job-lint:
         name: >-
             📚 Lint
-        runs-on: [self-hosted, macOS, general-ci]
+        runs-on: [self-hosted, macOS, mick-macbook]
         needs: [job-initialize]
         env:
             PACKAGE_VERSION: ${{ needs.job-initialize.outputs.package_version }}
@@ -246,7 +246,7 @@ jobs:
     job-test:
         name: >-
             🧪 Tests
-        runs-on: [self-hosted, macOS, general-ci]
+        runs-on: [self-hosted, macOS, mick-macbook]
         needs: [job-initialize]
         env:
             PACKAGE_VERSION: ${{ needs.job-initialize.outputs.package_version }}
@@ -306,7 +306,7 @@ jobs:
     job-complete-run:
         name: >-
             ✅ Complete
-        runs-on: [self-hosted, macOS, general-ci]
+        runs-on: [self-hosted, macOS, mick-macbook]
         needs: [job-initialize, job-lint, job-test]
         env:
             PACKAGE_VERSION: ${{ needs.job-initialize.outputs.package_version }}

--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -116,7 +116,7 @@ jobs:
     # #
 
     pr-autoscan:
-        runs-on: [self-hosted, macOS, general-ci]
+        runs-on: [self-hosted, macOS, mick-macbook]
         permissions:
             contents: read
             actions: read

--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -116,7 +116,7 @@ jobs:
     # #
 
     pr-autoscan:
-        runs-on: [self-hosted, macOS, mick-macbook]
+        runs-on: [self-hosted, macOS, general-ci]
         permissions:
             contents: read
             actions: read

--- a/build/tasks/grunt-run-test.js
+++ b/build/tasks/grunt-run-test.js
@@ -29,6 +29,8 @@ module.exports = function (grunt) {
             const browser = await puppeteer.launch({
                 headless: opt.headless,
                 executablePath,
+                dumpio: Boolean(process.env.CI),
+                pipe: Boolean(process.env.CI),
                 args: [
                     '--disable-dev-shm-usage',
                     '--disable-gpu',

--- a/build/tasks/grunt-run-test.js
+++ b/build/tasks/grunt-run-test.js
@@ -3,14 +3,32 @@ module.exports = function (grunt) {
         const done = this.async();
         const opt = this.options();
         const file = this.files[0].src[0];
+        const fs = require('fs');
         const path = require('path');
         const puppeteer = require('puppeteer');
+        function getChromeExecutablePath() {
+            if (process.env.CHROME_BIN) {
+                return process.env.CHROME_BIN;
+            }
+            if (process.env.CI && process.platform === 'darwin') {
+                const macChromePath =
+                    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+                if (fs.existsSync(macChromePath)) {
+                    return macChromePath;
+                }
+            }
+            return null;
+        }
         (async function () {
             grunt.log.writeln('Running tests...');
             const fullPath = 'file://' + path.resolve(file);
+            const executablePath = getChromeExecutablePath();
+            if (executablePath) {
+                grunt.log.writeln(`Using browser: ${executablePath}`);
+            }
             const browser = await puppeteer.launch({
                 headless: opt.headless,
-                executablePath: process.env.CHROME_BIN || null,
+                executablePath,
                 args: [
                     '--disable-dev-shm-usage',
                     '--disable-gpu',

--- a/build/tasks/grunt-run-test.js
+++ b/build/tasks/grunt-run-test.js
@@ -11,10 +11,27 @@ module.exports = function (grunt) {
             const browser = await puppeteer.launch({
                 headless: opt.headless,
                 executablePath: process.env.CHROME_BIN || null,
-                args: ['--disable-dev-shm-usage']
+                args: [
+                    '--disable-dev-shm-usage',
+                    '--disable-gpu',
+                    '--no-sandbox',
+                    '--disable-setuid-sandbox'
+                ]
             });
             grunt.log.writeln('puppeteer launched...');
             const page = await browser.newPage();
+            page.on('console', (message) => {
+                const type = message.type();
+                if (type === 'error' || type === 'warning') {
+                    grunt.log.writeln(`[browser:${type}] ${message.text()}`);
+                }
+            });
+            page.on('pageerror', (error) => {
+                grunt.fail.fatal(error.stack || error.message || error);
+            });
+            page.on('error', (error) => {
+                grunt.fail.fatal(error.stack || error.message || error);
+            });
             await page.goto(fullPath);
             async function check() {
                 const result = await page.evaluate(() => {
@@ -44,6 +61,8 @@ module.exports = function (grunt) {
             }
 
             check();
-        })();
+        })().catch((error) => {
+            grunt.fail.fatal(error.stack || error.message || error);
+        });
     });
 };

--- a/scripts/dev/build-macos-touchid-agent.sh
+++ b/scripts/dev/build-macos-touchid-agent.sh
@@ -8,9 +8,10 @@ Usage: scripts/dev/build-macos-touchid-agent.sh [options]
 Builds a signed arm64 KeeWeb macOS dev app with Touch ID support and deploys it.
 
 Options:
-  --deploy-path <path>   Target app path (default: /Applications/KeeWeb-Codex.app)
+  --deploy-path <path>   Target app path (default: /Applications/KeeWeb.app)
   --skip-build           Skip build/sign, only deploy from existing tmp build app
   --skip-deploy          Build/sign only, do not copy to /Applications
+  --no-backup            Replace the target app without creating a backup
   --no-open              Do not open app after deploy
   -h, --help             Show this help
 EOF
@@ -23,9 +24,10 @@ require_cmd() {
     fi
 }
 
-DEPLOY_PATH="/Applications/KeeWeb-Codex.app"
+DEPLOY_PATH="${DEPLOY_PATH:-/Applications/KeeWeb.app}"
 DO_BUILD=1
 DO_DEPLOY=1
+BACKUP_ON_DEPLOY="${BACKUP_ON_DEPLOY:-1}"
 OPEN_AFTER_DEPLOY=1
 
 while [[ $# -gt 0 ]]; do
@@ -40,6 +42,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-deploy)
             DO_DEPLOY=0
+            shift
+            ;;
+        --no-backup)
+            BACKUP_ON_DEPLOY=0
             shift
             ;;
         --no-open)
@@ -70,6 +76,30 @@ require_cmd /usr/bin/codesign
 require_cmd ditto
 require_cmd xattr
 
+ensure_node_runtime() {
+    local major
+
+    major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || true)"
+    if [[ "$major" == "20" ]]; then
+        return 0
+    fi
+
+    if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+        # shellcheck disable=SC1091
+        source "$HOME/.nvm/nvm.sh"
+        nvm use 20.5.1 >/dev/null 2>&1 || nvm use 20 >/dev/null 2>&1 || true
+        major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || true)"
+    fi
+
+    if [[ "$major" != "20" ]]; then
+        echo "KeeWeb's macOS packaging flow requires Node 20. Current node: $(node --version 2>/dev/null || echo missing)" >&2
+        echo "Install/use Node 20 before running this script." >&2
+        exit 1
+    fi
+}
+
+ensure_node_runtime
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 cd "$ROOT_DIR"
 
@@ -95,6 +125,39 @@ fi
 
 TEAM_ID="${APP_ID_FULL%%.*}"
 APP_BUNDLE_ID="${APP_ID_FULL#*.}"
+
+next_backup_deploy_path() {
+    local app_path="$1"
+    local timestamp app_dir app_name candidate counter
+
+    timestamp="$(date +%Y-%m-%d-%H-%M)"
+    app_dir="$(dirname "$app_path")"
+    app_name="$(basename "$app_path" .app)"
+    candidate="${app_dir}/${app_name}-backup-${timestamp}.app"
+    counter=1
+
+    while [[ -e "$candidate" ]]; do
+        candidate="${app_dir}/${app_name}-backup-${timestamp}-$(printf '%02d' "$counter").app"
+        counter=$((counter + 1))
+    done
+
+    printf '%s\n' "$candidate"
+}
+
+stop_running_app() {
+    /usr/bin/osascript -e "tell application id \"${APP_BUNDLE_ID}\" to quit" >/dev/null 2>&1 || true
+    pkill -f "$DEPLOY_PATH/Contents/MacOS/KeeWeb" >/dev/null 2>&1 || true
+
+    local attempt
+    for attempt in {1..20}; do
+        if ! pgrep -f "$DEPLOY_PATH/Contents/MacOS/KeeWeb" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    pkill -9 -f "$DEPLOY_PATH/Contents/MacOS/KeeWeb" >/dev/null 2>&1 || true
+}
 
 if [[ ! -d node_modules ]]; then
     echo "node_modules missing, running npm ci..."
@@ -158,8 +221,16 @@ if [[ ! -d "$APP_BUILD_PATH" ]]; then
 fi
 
 if [[ "$DO_DEPLOY" -eq 1 ]]; then
-    pkill -f "$DEPLOY_PATH/Contents/MacOS/KeeWeb" >/dev/null 2>&1 || true
-    rm -rf "$DEPLOY_PATH"
+    stop_running_app
+
+    if [[ "$BACKUP_ON_DEPLOY" -eq 1 && -d "$DEPLOY_PATH" ]]; then
+        BACKUP_PATH="$(next_backup_deploy_path "$DEPLOY_PATH")"
+        mv "$DEPLOY_PATH" "$BACKUP_PATH"
+        echo "Backup created: $BACKUP_PATH"
+    else
+        rm -rf "$DEPLOY_PATH"
+    fi
+
     ditto "$APP_BUILD_PATH" "$DEPLOY_PATH"
     xattr -cr "$DEPLOY_PATH"
     /usr/bin/codesign --verify --deep --strict --verbose=4 "$DEPLOY_PATH" >/dev/null


### PR DESCRIPTION
## Summary
- deploy the signed local macOS build to /Applications/KeeWeb.app by default
- back up the existing app before replacement and stop the running app before deploy
- require/switch to Node 20 for the macOS packaging flow
- keep /Applications/KeeWeb-Codex.app available via --deploy-path override and add --no-backup

## Verification
- bash -n scripts/dev/build-macos-touchid-agent.sh
- git diff --check
- scripts/dev/build-macos-touchid-agent.sh --no-open
- codesign --verify --deep --strict /Applications/KeeWeb.app