### PR TITLE
Recover Touch ID after biometric changes

### DIFF
--- a/app/scripts/comp/app/touch-id-recovery.js
+++ b/app/scripts/comp/app/touch-id-recovery.js
@@ -1,0 +1,116 @@
+import { Alerts } from 'comp/ui/alerts';
+import { Locale } from 'util/locale';
+
+const recoveryFileIds = new Set();
+let recoveryPromise = null;
+
+const TouchIdRecovery = {
+    handleDecryptionError(error, fileId) {
+        const isInvalidatedKey = /SecKeyCreateDecryptedData: OSStatus -1(?:\s|$)/.test(
+            error?.message || ''
+        );
+        if (isInvalidatedKey) {
+            recoveryFileIds.add(fileId);
+        }
+        return isInvalidatedKey;
+    },
+
+    isRequired(fileId) {
+        if (!recoveryFileIds.size) {
+            return false;
+        }
+        return (
+            fileId === undefined || recoveryFileIds.has(undefined) || recoveryFileIds.has(fileId)
+        );
+    },
+
+    async recover(model, file, params, nativeModules) {
+        if (!this.isRequired(file.id)) {
+            return false;
+        }
+        if (!recoveryPromise) {
+            recoveryPromise = (async () => {
+                await nativeModules.hardwareCryptoDeleteKey();
+                this.clearStoredPasswords(model);
+                const saved = await this.savePassword(model, file, params, nativeModules);
+                if (!saved) {
+                    throw new Error('Could not save the new Touch ID credentials');
+                }
+                recoveryFileIds.clear();
+                return true;
+            })();
+        }
+        try {
+            return await recoveryPromise;
+        } finally {
+            recoveryPromise = null;
+        }
+    },
+
+    async savePassword(model, file, params, nativeModules) {
+        if (!model.settings.deviceOwnerAuth || params.encryptedPassword) {
+            return false;
+        }
+        try {
+            const encryptedPassword = await nativeModules.hardwareEncrypt(params.password);
+            const value = encryptedPassword.toBase64();
+            const date = new Date();
+            file.encryptedPassword = value;
+            file.encryptedPasswordDate = date;
+            if (model.settings.deviceOwnerAuth === 'file') {
+                const fileInfo = model.fileInfos.get(file.id);
+                fileInfo.encryptedPassword = value;
+                fileInfo.encryptedPasswordDate = date;
+                model.fileInfos.save();
+            } else if (model.settings.deviceOwnerAuth === 'memory') {
+                model.memoryPasswordStorage[file.id] = { value, date };
+            }
+            return true;
+        } catch (error) {
+            file.encryptedPassword = null;
+            file.encryptedPasswordDate = null;
+            delete model.memoryPasswordStorage[file.id];
+            model.appLogger.error('Error encrypting password', error);
+            return false;
+        }
+    },
+
+    clearStoredPasswords(model) {
+        let fileInfoChanged = false;
+        for (const fileInfo of model.fileInfos) {
+            if (fileInfo.encryptedPassword) {
+                fileInfo.encryptedPassword = null;
+                fileInfo.encryptedPasswordDate = null;
+                fileInfoChanged = true;
+            }
+        }
+        if (fileInfoChanged) {
+            model.fileInfos.save();
+        }
+        for (const file of model.files) {
+            file.encryptedPassword = null;
+            file.encryptedPasswordDate = null;
+        }
+        for (const fileId of Object.keys(model.memoryPasswordStorage)) {
+            delete model.memoryPasswordStorage[fileId];
+        }
+    },
+
+    showRequiredAlert(complete) {
+        Alerts.error({
+            header: Locale.setGenTouchId,
+            body: Locale.touchIdRecoveryBody,
+            buttons: [Alerts.buttons.ok],
+            complete
+        });
+    },
+
+    showFailedAlert() {
+        Alerts.error({
+            header: Locale.openError,
+            body: Locale.touchIdRecoveryBody
+        });
+    }
+};
+
+export { TouchIdRecovery };

--- a/app/scripts/locales/base.json
+++ b/app/scripts/locales/base.json
@@ -215,7 +215,7 @@
   "openConfigErrorNotFound": "File not found",
   "openError": "Error",
   "openErrorDescription": "There was an error opening file",
-  "openErrorDescriptionMaybeTouchIdChanged": "The error looks similar to what usually happens when Touch ID setup is changed, for example, you added or removed an additional finger. If it's the case, go to Settings, disable Touch ID, and re-enable it again.",
+  "touchIdRecoveryBody": "Your Touch ID fingerprints changed, so macOS invalidated KeeWeb's previous security key. Select OK, then enter your master password once. After the database opens, KeeWeb reconnects Touch ID to your current fingerprints automatically. If it does not work, close and reopen the database and enter the master password again.",
   "openErrorFileNotFound": "File not found",
   "openListErrorBody": "There was an error loading file list",
   "openShowAllFiles": "Show all files",

--- a/app/scripts/locales/fr-FR.json
+++ b/app/scripts/locales/fr-FR.json
@@ -214,7 +214,7 @@
   "openConfigErrorNotFound": "Aucun fichier trouvé",
   "openError": "Erreur",
   "openErrorDescription": "Une erreur est survenue à l'ouverture du fichier",
-  "openErrorDescriptionMaybeTouchIdChanged": "L'erreur ressemble à ce qu'y arrive habituellement quand la configuration de Touch ID a été changée. Par exemple, vous avez ajouté ou supprimé un doigt supplémentaire. Si c'est le cas, allez dans Paramètres, désactiver Touch ID et activer le de nouveau.",
+  "touchIdRecoveryBody": "Vos empreintes Touch ID ont changé, macOS a donc invalidé l'ancienne clé de sécurité de KeeWeb. Sélectionnez OK, puis saisissez une fois votre mot de passe maître. Après l'ouverture de la base de données, KeeWeb reconnectera automatiquement Touch ID à vos empreintes actuelles. Si cela ne fonctionne pas, fermez puis rouvrez la base de données et saisissez de nouveau votre mot de passe maître.",
   "openErrorFileNotFound": "Fichier non trouvé",
   "openListErrorBody": "Erreur au chargement de la liste des fichiers",
   "openShowAllFiles": "Tous les fichiers",

--- a/app/scripts/models/app-model.js
+++ b/app/scripts/models/app-model.js
@@ -5,6 +5,7 @@ import { FileCollection } from 'collections/file-collection';
 import { FileInfoCollection } from 'collections/file-info-collection';
 import { RuntimeInfo } from 'const/runtime-info';
 import { UsbListener } from 'comp/app/usb-listener';
+import { TouchIdRecovery } from 'comp/app/touch-id-recovery';
 import { NativeModules } from 'comp/launcher/native-modules';
 import { Timeouts } from 'const/timeouts';
 import { AppSettingsModel } from 'models/app-settings-model';
@@ -879,7 +880,21 @@ class AppModel {
             }
         }
         if (this.settings.deviceOwnerAuth) {
-            this.saveEncryptedPassword(file, params);
+            if (!params) {
+                return;
+            }
+            if (TouchIdRecovery.isRequired()) {
+                if (!params.encryptedPassword && TouchIdRecovery.isRequired(file.id)) {
+                    return TouchIdRecovery.recover(this, file, params, NativeModules)
+                        .then(() => this.appLogger.info('Touch ID reconnected'))
+                        .catch((error) => {
+                            this.appLogger.error('Error reconnecting Touch ID', error);
+                            TouchIdRecovery.showFailedAlert();
+                        });
+                }
+                return;
+            }
+            return this.saveEncryptedPassword(file, params);
         }
     }
 
@@ -1362,33 +1377,7 @@ class AppModel {
     }
 
     saveEncryptedPassword(file, params) {
-        if (!this.settings.deviceOwnerAuth || params.encryptedPassword) {
-            return;
-        }
-        NativeModules.hardwareEncrypt(params.password)
-            .then((encryptedPassword) => {
-                encryptedPassword = encryptedPassword.toBase64();
-                const fileInfo = this.fileInfos.get(file.id);
-                const encryptedPasswordDate = new Date();
-                file.encryptedPassword = encryptedPassword;
-                file.encryptedPasswordDate = encryptedPasswordDate;
-                if (this.settings.deviceOwnerAuth === 'file') {
-                    fileInfo.encryptedPassword = encryptedPassword;
-                    fileInfo.encryptedPasswordDate = encryptedPasswordDate;
-                    this.fileInfos.save();
-                } else if (this.settings.deviceOwnerAuth === 'memory') {
-                    this.memoryPasswordStorage[file.id] = {
-                        value: encryptedPassword,
-                        date: encryptedPasswordDate
-                    };
-                }
-            })
-            .catch((e) => {
-                file.encryptedPassword = null;
-                file.encryptedPasswordDate = null;
-                delete this.memoryPasswordStorage[file.id];
-                this.appLogger.error('Error encrypting password', e);
-            });
+        return TouchIdRecovery.savePassword(this, file, params, NativeModules);
     }
 
     getMemoryPassword(fileId) {

--- a/app/scripts/views/open-view.js
+++ b/app/scripts/views/open-view.js
@@ -3,6 +3,7 @@ import { View } from 'framework/views/view';
 import { Events } from 'framework/events';
 import { Storage } from 'storage';
 import { DropboxChooser } from 'comp/app/dropbox-chooser';
+import { TouchIdRecovery } from 'comp/app/touch-id-recovery';
 import { FocusDetector } from 'comp/browser/focus-detector';
 import { KeyHandler } from 'comp/browser/key-handler';
 import { SecureInput } from 'comp/browser/secure-input';
@@ -736,11 +737,11 @@ class OpenView extends View {
                 })
                 .catch((err) => {
                     Events.emit('hardware-decrypt-finished');
-
                     if (err.message.includes('User refused')) {
                         err.userCanceled = true;
-                    } else if (err.message.includes('SecKeyCreateDecryptedData')) {
-                        err.maybeTouchIdChanged = true;
+                    } else if (TouchIdRecovery.handleDecryptionError(err, this.params.id)) {
+                        err.touchIdRecoveryRequired = true;
+                        this.encryptedPassword = null;
                     }
                     logger.error('Error in hardware decryption', err);
                     this.openDbComplete(err);
@@ -756,7 +757,7 @@ class OpenView extends View {
     openDbComplete(err) {
         this.busy = false;
         this.$el.toggleClass('open--opening', false);
-        const showInputError = err && !err.userCanceled;
+        const showInputError = err && !err.userCanceled && !err.touchIdRecoveryRequired;
         this.inputEl.removeAttr('disabled').toggleClass('input--error', !!showInputError);
         if (err) {
             logger.error('Error opening file', err);
@@ -767,17 +768,16 @@ class OpenView extends View {
                 InputFx.shake(this.inputEl);
             } else if (err.userCanceled) {
                 // nothing to do
+            } else if (err.touchIdRecoveryRequired) {
+                this.displayOpenDeviceOwnerAuth();
+                TouchIdRecovery.showRequiredAlert(() => this.focusInput(true));
             } else {
                 if (err.notFound) {
                     err = Locale.openErrorFileNotFound;
                 }
-                let alertBody = Locale.openErrorDescription;
-                if (err.maybeTouchIdChanged) {
-                    alertBody += '\n' + Locale.openErrorDescriptionMaybeTouchIdChanged;
-                }
                 Alerts.error({
                     header: Locale.openError,
-                    body: alertBody,
+                    body: Locale.openErrorDescription,
                     pre: this.errorToString(err)
                 });
             }

--- a/test/src/models/app-model-touch-id-recovery.js
+++ b/test/src/models/app-model-touch-id-recovery.js
@@ -1,0 +1,218 @@
+import { expect } from 'chai';
+import * as kdbxweb from 'kdbxweb';
+import { Collection } from 'framework/collection';
+import { TouchIdRecovery } from 'comp/app/touch-id-recovery';
+import { AppModel } from 'models/app-model';
+import { FileInfoModel } from 'models/file-info-model';
+import 'util/kdbxweb/protected-value-ex';
+
+describe('AppModel Touch ID recovery', () => {
+    class TestFileInfoCollection extends Collection {
+        static model = FileInfoModel;
+
+        saveCount = 0;
+
+        save() {
+            this.saveCount++;
+        }
+    }
+
+    it('replaces all stale Touch ID credentials after a successful password unlock', async () => {
+        const oldDate = new Date('2026-08-01T08:00:00Z');
+        const currentFileInfo = new FileInfoModel({
+            id: 'current',
+            name: 'Current',
+            encryptedPassword: 'old-current',
+            encryptedPasswordDate: oldDate
+        });
+        const otherFileInfo = new FileInfoModel({
+            id: 'other',
+            name: 'Other',
+            encryptedPassword: 'old-other',
+            encryptedPasswordDate: oldDate
+        });
+        const currentFile = {
+            id: 'current',
+            storage: 'test',
+            backup: null,
+            encryptedPassword: 'old-current',
+            encryptedPasswordDate: oldDate,
+            isKeyChangePending: () => false
+        };
+        const otherFile = {
+            id: 'other',
+            storage: 'test',
+            backup: null,
+            encryptedPassword: 'old-other',
+            encryptedPasswordDate: oldDate,
+            isKeyChangePending: () => false
+        };
+        const model = {
+            settings: { deviceOwnerAuth: 'file' },
+            fileInfos: new TestFileInfoCollection([currentFileInfo, otherFileInfo]),
+            files: [currentFile, otherFile],
+            memoryPasswordStorage: {
+                current: { value: 'old-current', date: oldDate },
+                other: { value: 'old-other', date: oldDate }
+            },
+            appLogger: { error() {} }
+        };
+
+        const operations = [];
+        const newEncryptedPassword = kdbxweb.ProtectedValue.fromString('new-encrypted-password');
+        const expectedEncryptedPassword = newEncryptedPassword.toBase64();
+        const nativeModules = {
+            async hardwareCryptoDeleteKey() {
+                operations.push('delete-key');
+            },
+            async hardwareEncrypt() {
+                operations.push('encrypt-password');
+                return newEncryptedPassword;
+            }
+        };
+
+        const invalidationError = new Error(
+            "Error invoking remote method 'hardwareDecrypt': Error: " +
+                'SecKeyCreateDecryptedData: OSStatus -1'
+        );
+        expect(TouchIdRecovery.handleDecryptionError(invalidationError)).to.be.true;
+        expect(TouchIdRecovery.isRequired()).to.be.true;
+
+        await TouchIdRecovery.recover(
+            model,
+            currentFile,
+            {
+                password: kdbxweb.ProtectedValue.fromString('master-password'),
+                encryptedPassword: null
+            },
+            nativeModules
+        );
+
+        expect(operations).to.eql(['delete-key', 'encrypt-password']);
+        expect(TouchIdRecovery.isRequired()).to.be.false;
+        expect(model.memoryPasswordStorage).to.eql({});
+        expect(otherFile.encryptedPassword).to.be.null;
+        expect(otherFile.encryptedPasswordDate).to.be.null;
+        expect(otherFileInfo.encryptedPassword).to.be.null;
+        expect(otherFileInfo.encryptedPasswordDate).to.be.null;
+        expect(currentFile.encryptedPassword).to.eql(expectedEncryptedPassword);
+        expect(currentFileInfo.encryptedPassword).to.eql(expectedEncryptedPassword);
+        expect(model.fileInfos.saveCount).to.eql(2);
+    });
+
+    it('does not request recovery for unrelated decryption errors', () => {
+        const unrelatedError = new Error('SecKeyCreateDecryptedData: OSStatus -50');
+
+        expect(TouchIdRecovery.handleDecryptionError(unrelatedError)).to.be.false;
+        expect(TouchIdRecovery.isRequired()).to.be.false;
+    });
+
+    it('leaves a pending recovery untouched when an XML import opens without password params', async () => {
+        const file = {
+            id: 'current',
+            storage: 'test',
+            backup: null,
+            encryptedPassword: null,
+            encryptedPasswordDate: null,
+            isKeyChangePending: () => false
+        };
+        const model = {
+            settings: { deviceOwnerAuth: 'file', yubiKeyAutoOpen: false },
+            fileInfos: new TestFileInfoCollection([
+                new FileInfoModel({ id: 'current', name: 'Current' })
+            ]),
+            files: [file],
+            memoryPasswordStorage: {},
+            appLogger: { error() {} }
+        };
+        const nativeModules = {
+            async hardwareCryptoDeleteKey() {},
+            async hardwareEncrypt() {
+                return kdbxweb.ProtectedValue.fromString('new-encrypted-password');
+            }
+        };
+        const invalidationError = new Error('SecKeyCreateDecryptedData: OSStatus -1');
+        TouchIdRecovery.handleDecryptionError(invalidationError, file.id);
+
+        let openError;
+        try {
+            AppModel.prototype.fileOpened.call(model, file);
+        } catch (error) {
+            openError = error;
+        }
+
+        await TouchIdRecovery.recover(
+            model,
+            file,
+            { password: kdbxweb.ProtectedValue.fromString('master-password') },
+            nativeModules
+        );
+        expect(openError).to.be.undefined;
+    });
+
+    it('serializes overlapping recovery attempts and only caches the first opened database', async () => {
+        const currentFileInfo = new FileInfoModel({ id: 'current', name: 'Current' });
+        const otherFileInfo = new FileInfoModel({ id: 'other', name: 'Other' });
+        const currentFile = {
+            id: 'current',
+            encryptedPassword: null,
+            encryptedPasswordDate: null
+        };
+        const otherFile = {
+            id: 'other',
+            encryptedPassword: null,
+            encryptedPasswordDate: null
+        };
+        const model = {
+            settings: { deviceOwnerAuth: 'file' },
+            fileInfos: new TestFileInfoCollection([currentFileInfo, otherFileInfo]),
+            files: [currentFile, otherFile],
+            memoryPasswordStorage: {},
+            appLogger: { error() {} }
+        };
+        const operations = [];
+        let continueDeletion;
+        const deletionBlocked = new Promise((resolve) => {
+            continueDeletion = resolve;
+        });
+        let deletionStarted;
+        const deletionStarting = new Promise((resolve) => {
+            deletionStarted = resolve;
+        });
+        const nativeModules = {
+            async hardwareCryptoDeleteKey() {
+                operations.push('delete-key');
+                deletionStarted();
+                await deletionBlocked;
+            },
+            async hardwareEncrypt() {
+                operations.push('encrypt-password');
+                return kdbxweb.ProtectedValue.fromString('new-encrypted-password');
+            }
+        };
+        const invalidationError = new Error('SecKeyCreateDecryptedData: OSStatus -1');
+        TouchIdRecovery.handleDecryptionError(invalidationError, currentFile.id);
+        TouchIdRecovery.handleDecryptionError(invalidationError, otherFile.id);
+
+        const currentRecovery = TouchIdRecovery.recover(
+            model,
+            currentFile,
+            { password: kdbxweb.ProtectedValue.fromString('current-password') },
+            nativeModules
+        );
+        await deletionStarting;
+        const otherRecovery = TouchIdRecovery.recover(
+            model,
+            otherFile,
+            { password: kdbxweb.ProtectedValue.fromString('other-password') },
+            nativeModules
+        );
+        continueDeletion();
+        await Promise.all([currentRecovery, otherRecovery]);
+
+        expect(operations).to.eql(['delete-key', 'encrypt-password']);
+        expect(currentFileInfo.encryptedPassword).to.be.a('string');
+        expect(otherFileInfo.encryptedPassword).to.be.null;
+        expect(TouchIdRecovery.isRequired()).to.be.false;
+    });
+});


### PR DESCRIPTION
## Summary

- detect Secure Enclave invalidation after the macOS fingerprint set changes
- require one successful master-password unlock before replacing the Touch ID key and stale password caches
- serialize recovery and preserve retry state across failures and alternate open paths
- provide localized recovery guidance in English and French

## Verification

- `NODE_OPTIONS=--openssl-legacy-provider CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npm test` — 88 passing
- `npm run lint`
- `python3 scripts/check-file-sizes.py`
- `git diff --check`
- independent two-pass code review: no critical or important findings
- signed macOS build deployed and live recovery flow confirmed