### PR TITLE
Use KeeWeb as the canonical app name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This file only adds repo-specific agent guidance.
    - arm64 build,
    - signed app generation,
    - provisioning profile wiring,
-   - atomic deploy to `/Applications/KeeWeb-Codex.app`,
+   - atomic deploy to `/Applications/KeeWeb.app`,
    - post-deploy signature verification.
 4. If it fails, stop and report:
    - script output,

--- a/docs/agents/handover-keeweb-codex.md
+++ b/docs/agents/handover-keeweb-codex.md
@@ -1,21 +1,21 @@
 # Übergabe KeeWeb-Codex
 
-Stand: 2026-08-18. Fork von KeeWeb (Electron 43, kein Rewrite): `mickdewald/keeweb` (origin), Upstream `keeweb/keeweb` (nur lesen, Fetch nur `master`, keine Tags). Ziel: schrittweise UX-Politur.
+Stand: 2026-08-24. KeeWeb-Codex ist Micks eigener Produkt-Fork von KeeWeb (Electron 43, kein Rewrite): `mickdewald/keeweb` (`origin`). Das ursprüngliche Projekt `keeweb/keeweb` ist als schreibgeschütztes `upstream` eingetragen (Fetch nur `master`, keine Tags). Ziel: schrittweise UX-Politur.
 
 ## Wo gearbeitet wird
 
 | Ort | Branch | Regel |
 |---|---|---|
-| `~/projects/external-repos/keeweb` | master | Nur lesen / `git pull --ff-only`. |
-| `~/projects/wt/keeweb-colorful-list-icons` | `grok/keeweb-colorful-list-icons` | Einzige Arbeitskopie; trackt eigene Remote-Branch. |
+| `~/projects/keeweb` | `master` | Kanonischer Checkout; nur lesen / `git pull --ff-only origin master`. |
+| `~/projects/wt/keeweb-<task>` | `codex/<task>` | Isolierte Arbeitskopie für die jeweilige Änderung, ausgehend von `origin/master`. |
 
-`node_modules` ist eine EIGENE Installation im Worktree (kein Symlink mehr — Electron 22 vs. master mit 13!). `keys/` bleibt lokal. **Nicht anfassen: mick.kdbx.**
+Jeder Worktree benötigt eine eigene `node_modules`-Installation (kein Symlink). `keys/` bleibt lokal. **Nicht anfassen: mick.kdbx.**
 
 ## Bauen / Testen / Deploy
 
 ```sh
 source ~/.nvm/nvm.sh && nvm use 20.5.1
-cd ~/projects/wt/keeweb-colorful-list-icons
+cd ~/projects/wt/keeweb-<task>
 NODE_OPTIONS=--openssl-legacy-provider \
   CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
   npx grunt build-test && \
@@ -32,24 +32,24 @@ Deploy (beendet die App hart, ungespeicherte kdbx-Änderungen sind weg):
 ./scripts/dev/build-macos-touchid-agent.sh
 ```
 
-Nie nach `/Applications/KeeWeb.app`. Das Deploy-Skript ersetzt `/Applications/KeeWeb-Codex.app`
+Das Deploy-Skript ersetzt `/Applications/KeeWeb.app`
 standardmäßig ohne App-Bundle-Backup, lintet (Prettier) und bricht bei Fehlern ab. Ein Backup ist
 nur als bewusstes Opt-in mit `--backup` erlaubt.
 
 Zum Klick-Testen ohne mick.kdbx: `npx grunt devsrv` (Port 8085) und die Demo-Datei im Browser öffnen.
 
-## Branch-Stand
+## Repository-Stand
 
-Arbeitsbranch: `grok/keeweb-colorful-list-icons` (nicht nach `origin/master` mergen, solange Mick das nicht will). Die echte App lebt auf dieser Branch.
+`origin/master` enthält den aktuellen Produktstand von KeeWeb-Codex. Der frühere Arbeitsbranch `grok/keeweb-colorful-list-icons` ist vollständig in `master` aufgegangen und existiert auf GitHub nicht mehr. Neue Änderungen erfolgen auf kurzlebigen `codex/*`-Branches in eigenen Worktrees und werden erst nach Micks Freigabe integriert.
 
-Darauf: Settings-Suche, bunte Listen-Icons, Details/Attachments, Trash+Restore, macOS-Chrome + Vibrancy, Ein-Sidebar-Layout, Such-Highlight, Auto-Backups, Copy-Hover, Cmd+K-Palette, farbige Passwort-Zeichen, Generator-Redesign, Electron 13→43 + safeStorage, Review-Fixes.
+In `master` enthalten: Settings-Suche, bunte Listen-Icons, Details/Attachments, Trash+Restore, macOS-Chrome + Vibrancy, Ein-Sidebar-Layout, Such-Highlight, Auto-Backups, Copy-Hover, Cmd+K-Palette, farbige Passwort-Zeichen, Generator-Redesign, Electron 13→43 + safeStorage, Review-Fixes.
 
 Abschluss 2026-08-18:
 
 - `06782863` Cmd+K: echtes Suchfeld, Palette bleibt bei 0 Treffern / leerem Passwort
 - `9782ad63` Devices/YubiKey aus Settings und Settings-Suche entfernt
 
-GitHub-Issues #1/#2 (UX-Backlog, Duplikat) sind geschlossen. Auf origin liegen nur `master` und diese Feature-Branch; Release-Tags von Vanilla-KeeWeb sind runter. Lokal bleibt der Tag `pre-single-sidebar`. `upstream` zeigt nur noch `keeweb/keeweb` `master`.
+GitHub-Issues #1/#2 (UX-Backlog, Duplikat) sind geschlossen. Auf `origin` liegt nur `master`; Release-Tags von Vanilla-KeeWeb sind entfernt. Der Tag `pre-single-sidebar` bleibt lokal und auf `origin`. `upstream` zeigt nur auf `keeweb/keeweb` `master` und wird ohne Tags gefetcht.
 
 ## Code-Pitfalls (mehrfach gebissen — zuerst lesen!)
 

--- a/docs/dev/macos-signed-touchid-build.md
+++ b/docs/dev/macos-signed-touchid-build.md
@@ -41,7 +41,7 @@ If `keys/keeweb.provisionprofile` is missing on this machine, copy it from the w
 
 ```bash
 mkdir -p keys
-cp /Applications/KeeWeb-Codex.app/Contents/embedded.provisionprofile keys/keeweb.provisionprofile
+cp /Applications/KeeWeb.app/Contents/embedded.provisionprofile keys/keeweb.provisionprofile
 ```
 
 Minimal `keys/codesign.json` example:
@@ -82,7 +82,7 @@ tmp/desktop/KeeWeb-darwin-arm64/KeeWeb.app
 
 ## Deploy for testing
 
-Use the canonical script. It replaces `/Applications/KeeWeb-Codex.app` without leaving a timestamped
+Use the canonical script. It replaces `/Applications/KeeWeb.app` without leaving a timestamped
 app backup behind:
 
 ```bash
@@ -94,9 +94,9 @@ For an exceptional recovery workflow, explicitly opt in with `--backup`.
 ## Verification checklist
 
 ```bash
-/usr/bin/codesign --verify --deep --strict --verbose=4 /Applications/KeeWeb-Codex.app
-/usr/bin/codesign -dvvv /Applications/KeeWeb-Codex.app | rg 'Identifier=|TeamIdentifier=|Authority='
-/usr/bin/codesign -d --entitlements :- /Applications/KeeWeb-Codex.app | rg 'application-identifier|team-identifier|keychain-access-groups'
+/usr/bin/codesign --verify --deep --strict --verbose=4 /Applications/KeeWeb.app
+/usr/bin/codesign -dvvv /Applications/KeeWeb.app | rg 'Identifier=|TeamIdentifier=|Authority='
+/usr/bin/codesign -d --entitlements :- /Applications/KeeWeb.app | rg 'application-identifier|team-identifier|keychain-access-groups'
 ```
 
 Expected:

--- a/scripts/dev/build-macos-touchid-agent.sh
+++ b/scripts/dev/build-macos-touchid-agent.sh
@@ -8,7 +8,7 @@ Usage: scripts/dev/build-macos-touchid-agent.sh [options]
 Builds a signed arm64 KeeWeb macOS dev app with Touch ID support and deploys it.
 
 Options:
-  --deploy-path <path>   Target app path (default: /Applications/KeeWeb-Codex.app)
+  --deploy-path <path>   Target app path (default: /Applications/KeeWeb.app)
   --skip-build           Skip build/sign, only deploy from existing tmp build app
   --skip-deploy          Build/sign only, do not copy to /Applications
   --backup               Back up the installed app before replacing it
@@ -24,7 +24,7 @@ require_cmd() {
     fi
 }
 
-DEPLOY_PATH="${DEPLOY_PATH:-/Applications/KeeWeb-Codex.app}"
+DEPLOY_PATH="${DEPLOY_PATH:-/Applications/KeeWeb.app}"
 DO_BUILD=1
 DO_DEPLOY=1
 BACKUP_ON_DEPLOY="${BACKUP_ON_DEPLOY:-0}"

--- a/scripts/dev/test-build-macos-touchid-agent.sh
+++ b/scripts/dev/test-build-macos-touchid-agent.sh
@@ -5,13 +5,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 TRACE="$(bash -x "$SCRIPT_DIR/build-macos-touchid-agent.sh" --help 2>&1)"
 BACKUP_TRACE="$(bash -x "$SCRIPT_DIR/build-macos-touchid-agent.sh" --backup --help 2>&1 || true)"
 
-if [[ "$TRACE" != *"DEPLOY_PATH=/Applications/KeeWeb-Codex.app"* ]]; then
-    echo "Expected the default deploy target to be /Applications/KeeWeb-Codex.app" >&2
+if [[ "$TRACE" != *"DEPLOY_PATH=/Applications/KeeWeb.app"* ]]; then
+    echo "Expected the default deploy target to be /Applications/KeeWeb.app" >&2
     exit 1
 fi
 
-if [[ "$TRACE" != *"default: /Applications/KeeWeb-Codex.app"* ]]; then
-    echo "Expected --help to document the KeeWeb-Codex.app deploy target" >&2
+if [[ "$TRACE" != *"default: /Applications/KeeWeb.app"* ]]; then
+    echo "Expected --help to document the KeeWeb.app deploy target" >&2
     exit 1
 fi
 

--- a/scripts/dev/update-electron.sh
+++ b/scripts/dev/update-electron.sh
@@ -39,8 +39,8 @@ npx grunt run-test
 cat <<'EOF'
 
 Next steps:
-  1. Deploy: ./scripts/dev/build-macos-touchid-agent.sh --deploy-path /Applications/KeeWeb-Codex.app
-     (keep the automatic backup on major version jumps)
+  1. Deploy: ./scripts/dev/build-macos-touchid-agent.sh
+     (use --backup only when an app-bundle backup is explicitly needed)
   2. Test in the app: Touch ID unlock, save, Cmd+K.
   3. macOS will re-ask keychain permissions once (new binary signature) - click "Always Allow".
   4. Commit package.json + package-lock.json.


### PR DESCRIPTION
## Summary

- document `~/projects/keeweb` as the canonical product checkout
- make `/Applications/KeeWeb.app` the default signed macOS deploy target
- update the deploy policy regression test and macOS build documentation

## Verification

- 128 application tests passed
- lint passed
- macOS deploy policy test passed
- shell syntax and diff checks passed
- signed arm64 app deployed and launched successfully from `/Applications/KeeWeb.app`
